### PR TITLE
Add nmap to alpine dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Thomas <thomasvt@me.com>
 ADD https://raw.githubusercontent.com/home-assistant/home-assistant/master/requirements_all.txt /
 
 # Update application repository list and install the HASS server. 
-RUN apk add --no-cache git mariadb-client-libs python3 autoconf ca-certificates glib-dev libffi-dev jpeg-dev eudev-dev zlib-dev py3-lxml libssl1.0 libressl-dev && \
+RUN apk add --no-cache git mariadb-client-libs python3 autoconf nmap ca-certificates glib-dev libffi-dev jpeg-dev eudev-dev zlib-dev py3-lxml libssl1.0 libressl-dev && \
     pip3 install --upgrade --no-cache-dir pip && \
     apk add --no-cache --virtual=build-dependencies build-base linux-headers python3-dev tzdata mariadb-dev && \
     pip3 install --no-cache-dir homeassistant && \


### PR DESCRIPTION
To avoid:
```
2019-01-06 21:06:08 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/homeassistant/components/device_tracker/__init__.py", line 708, in async_device_tracker_scan
    found_devices = await scanner.async_scan_devices()
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3.6/site-packages/homeassistant/components/device_tracker/nmap_tracker.py", line 81, in scan_devices
    self._update_info()
  File "/usr/lib/python3.6/site-packages/homeassistant/components/device_tracker/nmap_tracker.py", line 111, in _update_info
    scanner = PortScanner()
  File "/usr/lib/python3.6/site-packages/nmap/nmap.py", line 131, in __init__
    os.getenv('PATH')
nmap.nmap.PortScannerError: 'nmap program was not found in path. PATH is : /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
```